### PR TITLE
Adding retries for apt-get

### DIFF
--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -ex
+# We allow failures
+#set -ex
 
 max_attempts=5
 attempt=1

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 set -ex
 
-# install pre-requisites
-./install_prerequisites.sh
+max_attempts=5
+attempt=1
+while [[ ! -f /usr/bin/jq && $attempt -le $max_attempts ]]; do
+	# install pre-requisites
+ 	# We need to disable 'set -ex' to retry
+	./install_prerequisites.sh
+	attempt=$((attempt + 1))
+	if [[ ! -f /usr/bin/jq ]]; then
+		echo "Prerequisites installation failed, retrying..."
+		sleep 30  # Wait for locks to be released
+	fi
+done
 
 export GPU="NVIDIA"
 
@@ -36,7 +46,15 @@ time ./install_utils.sh
 # $UBUNTU_COMMON_DIR/install_mpis.sh
 
 echo "Install nvidia gpu driver"
-time $UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh
+attempt=1
+while [[ ! -f /usr/bin/nvidia-smi && $attempt -le $max_attempts ]]; do
+	time $UBUNTU_COMMON_DIR/install_nvidiagpudriver.sh
+	attempt=$((attempt + 1))
+	if [[ ! -f /usr/bin/nvidia-smi ]]; then
+		echo "NVIDIA driver installation failed, retrying..."
+		sleep 30  # Wait for locks to be released
+	fi
+done
 
 echo "Install NCCL"
 time $UBUNTU_COMMON_DIR/install_nccl.sh
@@ -51,7 +69,15 @@ rm -rf /var/intel/ /var/cache/*
 rm -Rf -- */
 
 echo "Install DCGM"
-time $UBUNTU_COMMON_DIR/install_dcgm.sh
+attempt=1
+while [[ ! -f /usr/bin/dcgmi && $attempt -le $max_attempts ]]; do
+	time $UBUNTU_COMMON_DIR/install_dcgm.sh
+	attempt=$((attempt + 1))
+	if [[ ! -f /usr/bin/dcgmi ]]; then
+		echo "NVIDIA driver installation failed, retrying..."
+		sleep 30  # Wait for locks to be released
+	fi
+done
 
 echo "Install Intel libraries"
 time $COMMON_DIR/install_intel_libs.sh

--- a/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_prerequisites.sh
+++ b/ubuntu/ubuntu-20.x/ubuntu-20.04-hpc/install_prerequisites.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -ex
+# We allow failing
+#set -ex
 
 # Don't allow the kernel to be updated
 apt-mark hold linux-azure


### PR DESCRIPTION
Other Azure daemons are running apt-get operations.
This adds retries.